### PR TITLE
fix: Fix usage of jq for check existing releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: IceRaven OLED Auto-Release
 
 on:
   schedule:
-    - cron: '00 0 * * *'
+    - cron: "00 0 * * *"
   workflow_dispatch:
 
 concurrency:
@@ -33,8 +33,8 @@ jobs:
           tag_exists=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
             "https://api.github.com/repos/${{ github.repository }}/tags" \
             | jq -r --arg tag "${{ steps.get_upstream.outputs.tag }}" \
-            'any(.name == $tag; .)')
-          
+            'any(.[].name == $tag; .)')
+
           # Set output based on tag existence
           if [[ "$tag_exists" == "true" ]]; then
             echo "new_version=false" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Hello. Recently, I came across Iceraven-OLED for the first time, and I think it’s very useful. Thanks to it, I can enjoy a browser with extension support that is also easier on the eyes with less eye strain.

While trying to build in myself, I noticed there was an issue likely caused by incorrect usage of `jq`. I checked your GitHub Action history and saw that errors were occurring.

> jq: error (at <stdin>:102): Cannot index array with string "name"

I made a simple fix, and I believe that once this is merged, the periodic action failures should be resolved.

Thank you!