### PR TITLE
Remove --use-aapt2 and Fix Cleanup Typo in build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -22,10 +22,10 @@ sed -i 's/ff42414d/ff15141a/g' iceraven-patched/smali*/mozilla/components/ui/col
 sed -i 's/ff52525e/ff15141a/g' iceraven-patched/smali*/mozilla/components/ui/colors/PhotonColors.smali
 
 # Recompile the APK
-java -jar apktool.jar b iceraven-patched -o iceraven-patched.apk --use-aapt2
+java -jar apktool.jar b iceraven-patched -o iceraven-patched.apk
 
 # Align and sign the APK
 zipalign 4 iceraven-patched.apk iceraven-patched-signed.apk
 
 # Clean up
-rm -rf iceraven-patched iceraven-patch ed.apk
+rm -rf iceraven-patched iceraven-patched.apk


### PR DESCRIPTION
This PR fixes two issues in `build.sh`:

- Removed the `--use-aapt2` flag from the `apktool b` command, which caused a build error in `apktool` 2.12.0 (unrecognized option). The default `aapt2` is used instead.
- Fixed a typo in the cleanup step (`iceraven-patch ed.apk` → `iceraven-patched.apk`) to cleanup.
