### PR TITLE
Update color targets for Fenix 147 Material3 migration

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -8,7 +8,8 @@ java -jar apktool.jar d iceraven.apk -o iceraven-patched  # -s flag removed
 rm -rf iceraven-patched/META-INF
 
 # Color patching
-sed -i 's/<color name="fx_mobile_layer_color_1">.*/<color name="fx_mobile_layer_color_1">#ff000000<\/color>/g' iceraven-patched/res/values-night/colors.xml
+sed -i 's/<color name="fx_mobile_surface">.*/<color name="fx_mobile_surface">#ff000000<\/color>/g' iceraven-patched/res/values-night/colors.xml
+sed -i 's/<color name="fx_mobile_background">.*/<color name="fx_mobile_background">#ff000000<\/color>/g' iceraven-patched/res/values-night/colors.xml
 sed -i 's/<color name="fx_mobile_layer_color_2">.*/<color name="fx_mobile_layer_color_2">@color\/photonDarkGrey90<\/color>/g' iceraven-patched/res/values-night/colors.xml
 
 # Smali patching


### PR DESCRIPTION
Hey, thanks for maintaining this project!

OLED patch stopped working on 2.40. Diffed the tags and traced it to Mozilla's Material3 migration in Fenix 147.

Upstream commit [cecf1da479](https://github.com/fork-maintainers/iceraven-browser/commit/cecf1da479) ([Bug 1993368](https://bugzilla.mozilla.org/show_bug.cgi?id=1993368)) removed `fx_mobile_layer_color_1`
and replaced it with `fx_mobile_surface` / `fx_mobile_background`.

Fix: target the new color names.

Tested on 2.40.0 arm64-v8a, screenshots attached.

Closes #22